### PR TITLE
feat: standardize certificate handling with BASE64-only approach

### DIFF
--- a/.github/actions/sign-executable/action.yml
+++ b/.github/actions/sign-executable/action.yml
@@ -60,6 +60,18 @@ runs:
       shell: bash
       run: |
         echo "Starting signing process..."
+        
+        # Determine Docker image tag based on action version
+        if [ -n "$GITHUB_ACTION_REF" ]; then
+          # Use the same tag as the action version (e.g., v1.0.0)
+          DOCKER_TAG="$GITHUB_ACTION_REF"
+          echo "Using Docker image: ricardopaes/exe-sign:$DOCKER_TAG"
+        else
+          # Fallback to latest for local development
+          DOCKER_TAG="latest"
+          echo "Using Docker image: ricardopaes/exe-sign:$DOCKER_TAG (fallback)"
+        fi
+        
         docker run --rm \
           -v ${{ github.workspace }}/signing-work:/work \
           -e CERTIFICATE_BASE64="${{ inputs.certificate-base64 }}" \
@@ -68,7 +80,7 @@ runs:
           -e EXE_SIGNED="${{ inputs.signed-executable-name }}" \
           -e PASSWORD="${{ inputs.signing-password }}" \
           -e TIMESTAMP="${{ inputs.timestamp-url }}" \
-          ricardopaes/exe-sign:latest
+          ricardopaes/exe-sign:$DOCKER_TAG
         
         # Set output
         echo "signed-path=${{ github.workspace }}/signing-work/${{ inputs.signed-executable-name }}" >> $GITHUB_OUTPUT

--- a/.github/actions/sign-executable/action.yml
+++ b/.github/actions/sign-executable/action.yml
@@ -40,12 +40,6 @@ runs:
       shell: bash
       run: mkdir -p ${{ github.workspace }}/signing-work
 
-    - name: Decode certificate
-      shell: bash
-      run: |
-        echo "${{ inputs.certificate-base64 }}" | base64 -d > ${{ github.workspace }}/signing-work/certificate.pfx
-        echo "Certificate decoded successfully"
-
     - name: Verify executable exists
       shell: bash
       run: |
@@ -74,7 +68,7 @@ runs:
           -e EXE_SIGNED="${{ inputs.signed-executable-name }}" \
           -e PASSWORD="${{ inputs.signing-password }}" \
           -e TIMESTAMP="${{ inputs.timestamp-url }}" \
-          ricardoapaes/exe-sign:latest
+          ricardopaes/exe-sign:latest
         
         # Set output
         echo "signed-path=${{ github.workspace }}/signing-work/${{ inputs.signed-executable-name }}" >> $GITHUB_OUTPUT
@@ -89,10 +83,3 @@ runs:
         fi
         echo "Signed executable verified: ${{ github.workspace }}/signing-work/${{ inputs.signed-executable-name }}"
         ls -la ${{ github.workspace }}/signing-work/${{ inputs.signed-executable-name }}
-
-    - name: Cleanup certificate
-      shell: bash
-      if: always()
-      run: |
-        rm -f ${{ github.workspace }}/signing-work/certificate.pfx
-        echo "Certificate file cleaned up"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -84,7 +84,7 @@ jobs:
             -e CERTIFICATE_PASSWORD="${{ secrets.CERTIFICATE_PASSWORD }}" \
             --entrypoint="" \
             ${{ env.IMAGE_NAME }}:latest \
-            sh -c 'apk add --no-cache openssl && echo "$CERTIFICATE_BASE64" | base64 -d | openssl pkcs12 -info -password "pass:$CERTIFICATE_PASSWORD" -noout'
+            sh -c 'echo "$CERTIFICATE_BASE64" | base64 -d | openssl pkcs12 -info -password "pass:$CERTIFICATE_PASSWORD" -noout'
           
           # Run the actual signing process
           echo "✍️  Signing executable..."

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -83,8 +83,8 @@ jobs:
             -e CERTIFICATE_BASE64="${{ secrets.CERTIFICATE_BASE64 }}" \
             -e CERTIFICATE_PASSWORD="${{ secrets.CERTIFICATE_PASSWORD }}" \
             --entrypoint="" \
-            ${{ env.IMAGE_NAME }}:pr-${{ github.event.number }} \
-            sh -c 'echo "$CERTIFICATE_BASE64" | base64 -d > /tmp/cert.pfx && openssl pkcs12 -info -in /tmp/cert.pfx -password "pass:$CERTIFICATE_PASSWORD" -noout'
+            ${{ env.IMAGE_NAME }}:latest \
+            sh -c 'apk add --no-cache openssl && echo "$CERTIFICATE_BASE64" | base64 -d | openssl pkcs12 -info -password "pass:$CERTIFICATE_PASSWORD" -noout'
           
           # Run the actual signing process
           echo "✍️  Signing executable..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
             -e CERTIFICATE_PASSWORD="${{ secrets.CERTIFICATE_PASSWORD }}" \
             --entrypoint="" \
             ${{ env.IMAGE_NAME }}:latest \
-            sh -c 'apk add --no-cache openssl && echo "$CERTIFICATE_BASE64" | base64 -d | openssl pkcs12 -info -password "pass:$CERTIFICATE_PASSWORD" -noout'
+            sh -c 'echo "$CERTIFICATE_BASE64" | base64 -d | openssl pkcs12 -info -password "pass:$CERTIFICATE_PASSWORD" -noout'
           
           # Test that the latest image runs and signs successfully
           echo "✍️  Testing signing process..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: likesistemas/exe-sign
+  IMAGE_NAME: ricardopaes/exe-sign
 
 jobs:
   build-and-push:
@@ -64,9 +64,8 @@ jobs:
         run: |
           echo "Testing the release image with real executable and certificate..."
           
-          # Copy the real certificate from work directory
+          # Create test directory
           mkdir -p test-work
-          cp work/certificate.pfx test-work/
           
           # Download a simple Windows executable for testing (7zip command line)
           echo "📥 Downloading test executable..."
@@ -85,15 +84,17 @@ jobs:
           echo "🔐 Testing certificate..."
           docker run --rm \
             -v ${{ github.workspace }}/test-work:/work \
+            -e CERTIFICATE_BASE64="${{ secrets.CERTIFICATE_BASE64 }}" \
             -e CERTIFICATE_PASSWORD="${{ secrets.CERTIFICATE_PASSWORD }}" \
             --entrypoint="" \
             ${{ env.IMAGE_NAME }}:latest \
-            openssl pkcs12 -info -in /work/certificate.pfx -password "pass:${{ secrets.CERTIFICATE_PASSWORD }}" -noout
+            sh -c 'apk add --no-cache openssl && echo "$CERTIFICATE_BASE64" | base64 -d | openssl pkcs12 -info -password "pass:$CERTIFICATE_PASSWORD" -noout'
           
           # Test that the latest image runs and signs successfully
           echo "✍️  Testing signing process..."
           docker run --rm \
             -v ${{ github.workspace }}/test-work:/work \
+            -e CERTIFICATE_BASE64="${{ secrets.CERTIFICATE_BASE64 }}" \
             -e CERTIFICATE_PASSWORD="${{ secrets.CERTIFICATE_PASSWORD }}" \
             -e EXE_FILE="7za.exe" \
             -e EXE_SIGNED="7za-signed.exe" \
@@ -162,12 +163,14 @@ jobs:
             # Using latest
             docker run --rm \\
               -v \${PWD}/work:/work \\
+              -e CERTIFICATE_BASE64="your_base64_certificate" \\
               -e CERTIFICATE_PASSWORD="your_password" \\
               ${{ env.IMAGE_NAME }}:latest
             
             # Using specific version
             docker run --rm \\
               -v \${PWD}/work:/work \\
+              -e CERTIFICATE_BASE64="your_base64_certificate" \\
               -e CERTIFICATE_PASSWORD="your_password" \\
               ${{ env.IMAGE_NAME }}:${tagName}
             \`\`\`
@@ -176,7 +179,7 @@ jobs:
             
             \`\`\`yaml
             - name: Sign executable
-              uses: likesistemas/exe-sign@${tagName}
+              uses: ricardoapaes/exe-sign@${tagName}
               with:
                 executable-path: 'dist/app.exe'
                 certificate-base64: \${{ secrets.CERTIFICATE_BASE64 }}

--- a/README.md
+++ b/README.md
@@ -106,6 +106,27 @@ jobs:
     signing-password: ${{ secrets.SIGNING_PASSWORD }} # optional
 ```
 
+### 🏷️ Version Management
+
+The action automatically uses the Docker image that matches the action version:
+
+- When you use `ricardoapaes/exe-sign@v1.2.0`, it will use the Docker image `ricardopaes/exe-sign:v1.2.0`
+- When you use `ricardoapaes/exe-sign@main`, it will use the Docker image `ricardopaes/exe-sign:latest`
+- This ensures consistency between the action version and the underlying Docker image
+
+**Recommended versioning:**
+
+```yaml
+# ✅ Use specific versions for production
+uses: ricardoapaes/exe-sign@v1.2.0
+
+# ✅ Use major version for automatic updates
+uses: ricardoapaes/exe-sign@v1
+
+# ⚠️ Use main/latest only for development
+uses: ricardoapaes/exe-sign@main
+```
+
 ### Using the Reusable Workflow
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -40,12 +40,6 @@ runs:
       shell: bash
       run: mkdir -p ${{ github.workspace }}/signing-work
 
-    - name: Decode certificate
-      shell: bash
-      run: |
-        echo "${{ inputs.certificate-base64 }}" | base64 -d > ${{ github.workspace }}/signing-work/certificate.pfx
-        echo "✅ Certificate decoded successfully"
-
     - name: Verify executable exists
       shell: bash
       run: |
@@ -74,7 +68,7 @@ runs:
           -e EXE_SIGNED="${{ inputs.signed-executable-name }}" \
           -e PASSWORD="${{ inputs.signing-password }}" \
           -e TIMESTAMP="${{ inputs.timestamp-url }}" \
-          ricardoapaes/exe-sign:latest
+          ricardopaes/exe-sign:latest
         
         # Set output
         echo "signed-path=${{ github.workspace }}/signing-work/${{ inputs.signed-executable-name }}" >> $GITHUB_OUTPUT
@@ -89,10 +83,3 @@ runs:
         fi
         echo "✅ Signed executable verified: ${{ inputs.signed-executable-name }}"
         echo "📊 File size: $(ls -lh ${{ github.workspace }}/signing-work/${{ inputs.signed-executable-name }} | awk '{print $5}')"
-
-    - name: Cleanup certificate
-      shell: bash
-      if: always()
-      run: |
-        rm -f ${{ github.workspace }}/signing-work/certificate.pfx
-        echo "🧹 Certificate file cleaned up"

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,18 @@ runs:
       shell: bash
       run: |
         echo "🔐 Starting signing process..."
+        
+        # Determine Docker image tag based on action version
+        if [ -n "$GITHUB_ACTION_REF" ]; then
+          # Use the same tag as the action version (e.g., v1.0.0)
+          DOCKER_TAG="$GITHUB_ACTION_REF"
+          echo "📦 Using Docker image: ricardopaes/exe-sign:$DOCKER_TAG"
+        else
+          # Fallback to latest for local development
+          DOCKER_TAG="latest"
+          echo "📦 Using Docker image: ricardopaes/exe-sign:$DOCKER_TAG (fallback)"
+        fi
+        
         docker run --rm \
           -v ${{ github.workspace }}/signing-work:/work \
           -e CERTIFICATE_BASE64="${{ inputs.certificate-base64 }}" \
@@ -68,7 +80,7 @@ runs:
           -e EXE_SIGNED="${{ inputs.signed-executable-name }}" \
           -e PASSWORD="${{ inputs.signing-password }}" \
           -e TIMESTAMP="${{ inputs.timestamp-url }}" \
-          ricardopaes/exe-sign:latest
+          ricardopaes/exe-sign:$DOCKER_TAG
         
         # Set output
         echo "signed-path=${{ github.workspace }}/signing-work/${{ inputs.signed-executable-name }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
feat: standardize certificate handling with BASE64-only approach

Major architectural improvements and standardization:

- Standardize variable names from CERT_* to CERTIFICATE_* across all files
- Implement BASE64-only certificate handling, removing file dependencies
- Update Docker Hub username from likesistemas to ricardopaes
- Eliminate temporary certificate files in favor of pipe-based validation
- Simplify GitHub Actions workflows by removing file operations
- Enhance security by avoiding certificate files on disk
- Maintain backward compatibility with comprehensive documentation

Technical changes:
- sign.sh: Rewritten to handle CERTIFICATE_BASE64 internally
- GitHub Actions: Streamlined to pass BASE64 directly to containers
- Workflows: Updated certificate validation to use OpenSSL pipes
- Documentation: Updated examples for BASE64 approach

This change improves security, portability, and consistency while
maintaining full functionality for executable signing workflows.

Fixes variable naming inconsistencies and eliminates security risks
associated with certificate files in the filesystem.